### PR TITLE
Add GitHub labels for repository settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,6 +13,8 @@ labels:
     color: 009800
   - name: 'Status: Available'
     color: bfe5bf
+  - name: 'Status: Planned'
+    color: 30336b
   - name: 'Status: Blocked'
     color: e11d21
   - name: 'Status: Completed'
@@ -23,6 +25,8 @@ labels:
     color: e11d21
   - name: 'Status: Pending'
     color: fef2c0
+  - name: 'Status: Reviewed'
+    color: 6ab04c
   - name: 'Status: Review Needed'
     color: fbca04
   - name: 'Status: Revision Needed'
@@ -37,3 +41,5 @@ labels:
     color: 84b6eb
   - name: 'Type: Question'
     color: cc317c
+  - name: good first issue
+    color: 22a6b3

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,39 @@
+labels:
+  - name: 'Priority: Low'
+    color: 009800
+  - name: 'Priority: Medium'
+    color: fbca04
+  - name: 'Priority: High'
+    color: eb6420
+  - name: 'Priority: Critical'
+    color: e11d21
+  - name: 'Status: Abandoned'
+    color: 000000
+  - name: 'Status: Accepted'
+    color: 009800
+  - name: 'Status: Available'
+    color: bfe5bf
+  - name: 'Status: Blocked'
+    color: e11d21
+  - name: 'Status: Completed'
+    color: 006b75
+  - name: 'Status: In Progress'
+    color: cccccc
+  - name: 'Status: On Hold'
+    color: e11d21
+  - name: 'Status: Pending'
+    color: fef2c0
+  - name: 'Status: Review Needed'
+    color: fbca04
+  - name: 'Status: Revision Needed'
+    color: e11d21
+  - name: 'Type: Bug'
+    color: e11d21
+  - name: 'Type: Maintenance'
+    color: fbca04
+  - name: 'Type: Idea'
+    color: 009432
+  - name: 'Type: Enhancement'
+    color: 84b6eb
+  - name: 'Type: Question'
+    color: cc317c


### PR DESCRIPTION
## Purpose

I've added the labels that were mentioned from #162.

## Deployment

All labels will need to be deleted from this repository before merging this PR.

Take note on what labels currently are being used on the issues and pull requests so that they can be added back to them using the newly created labels.

## Other

Any questions or concerns please @tag me.
The current issue/label associations: https://i.imgur.com/LNGxbbi.png (as of 2019/10/10 13:40)