### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@
 trigger:
     - master
     - develop
+    - greenkeeper/*
 
 pool:
     vmImage: 'ubuntu-latest'


### PR DESCRIPTION
Trigger Azure CI for greenkeeper branches, part of #160 

@J-Graham @chriscamac This will fire off CI for any branch starting with ```greenkeeper/```.

We should make sure that each branch in Azure builds to it's own directory, so that greenkeeper doesn't overwrite the live demo. 

We also need to have greenkeeper recreate it's ```initial``` branch. See #166 